### PR TITLE
Make link surrounding card react-router link

### DIFF
--- a/src/components/pages/home-page/feature-card/index.tsx
+++ b/src/components/pages/home-page/feature-card/index.tsx
@@ -1,4 +1,5 @@
 import { Box, Image, Link, Text } from '@chakra-ui/react';
+import { NavLink } from 'react-router-dom';
 
 interface Props {
   heading: string;
@@ -11,7 +12,7 @@ interface Props {
 
 const FeatureCard = ({ heading, image, route }: Props) => {
   return (
-    <Link href={route} _hover={{ textDecoration: 'none' }}>
+    <Link as={NavLink} to={route} _hover={{ textDecoration: 'none' }}>
       <Box
         boxShadow="lg"
         rounded="md"


### PR DESCRIPTION
Closes #5 

Followed same reproduction steps but worked locally.

However found link did not use react router link (and used default Chakra link) instead so no client side routing which may be the issue.